### PR TITLE
Check Empty - PEP8 style guide 

### DIFF
--- a/src/zabbix/base.py
+++ b/src/zabbix/base.py
@@ -1,7 +1,7 @@
 def find_group_by_name(zabbix_api, name):
     groups = zabbix_api.hostgroup.get(filter={'name': str(name)})
 
-    if len(groups) == 0:
+    if not groups:
         return []
 
     return groups[0]


### PR DESCRIPTION
* Code based on [PEP 8 Style Guide](https://www.python.org/dev/peps/pep-0008/)

> For sequences, (strings, lists, tuples), use the fact that empty sequences are false